### PR TITLE
RPM package sources

### DIFF
--- a/rpm/README.md
+++ b/rpm/README.md
@@ -1,0 +1,44 @@
+# RPM package spec file
+
+## How to build the rpm package in fedora
+
+ * Setting up the environment
+
+```
+# dnf install @development-tools
+# dnf install fedora-packager
+# dnf install rpmdevtools
+```
+
+ * Adding my user to mock group. MYUSER is a non-root user.
+
+```
+# usermod -a -G mock MYUSER
+```
+
+ * As MYUSER, setup the rpm dev tree
+
+```
+$ rpmdev-setuptree
+```
+
+ * Copy the .spec file to your SPECS folder and the code to the SOURCES
+   folder
+
+```
+$ cp SyncMe/rpm/SyncMe.spec ~/rpmbuild/SPECS/
+$ mv SyncMe SyncMe-VERSION
+$ tar -czvf SyncMe-VERSION.tar.gz SyncMe-VERSION
+$ cp SyncMe-VERSION.tar.gz ~/rpmbuild/SOURCES/
+```
+
+ * Update the .spec file incrementing the version and adding a new line in
+   the changelog
+ * Build the package
+
+```
+$ cd  ~/rpmbuild/SPECS/
+$ rmpbuild -ba SyncMe.spec
+```
+
+ * If nothing fails the RPM should be in ~/rpmbuild/RPMS/

--- a/rpm/SyncMe.spec
+++ b/rpm/SyncMe.spec
@@ -1,0 +1,46 @@
+Name:           SyncMe
+Version:        0.3
+Release:        1%{?dist}
+Summary:        Application to unify the synchronization of Dropbox and Google Drive
+
+License:        GPLv3
+URL:            https://github.com/AdrianBZG/SyncMe/
+Source0:        SyncMe-0.3.tar.gz
+
+BuildRequires:  qt5-qtbase-devel qt5-qtwebkit-devel
+Requires:       qt5-qtbase qt5-qtwebkit openssl
+
+%description
+SyncMe is a cross-platform application (Linux, Windows, Mac) written in Qt5
+and C++ with the main goal of unify the synchronization of Dropbox and
+Google Drive platforms into a single application, allowing you to manage
+all your files easily.
+
+
+%prep
+%setup -q
+
+
+%build
+mkdir build
+cd build
+qmake-qt5 ../src/SyncMe/SyncMe.pro
+make
+
+%install
+#rm -rf $RPM_BUILD_ROOT
+#%make_install
+install -m 755 -d %{buildroot}/%{_bindir}
+install -m 755 build/SyncMe %{buildroot}/%{_bindir}/SyncMe
+
+
+
+%files
+%{_bindir}/*
+
+%doc
+%license LICENSE
+
+%changelog
+* Fri May  6 2016 Daniel García Moreno <danigm@wadobo.com> -- 0.3.1%{?dist}
+- Initial version of the package


### PR DESCRIPTION
I've created the rpm spec file to create the fedora package. Here is a build for fedora 24: 
http://danigm.net/SyncMe-0.3-1.fc24.x86_64.rpm

It's possible to create the deb package using the rpm as base, with the alien program:

https://wiki.debian.org/Alien